### PR TITLE
Extend timeout for Clamav scan

### DIFF
--- a/.tekton/fms-hf-tuning-push.yaml
+++ b/.tekton/fms-hf-tuning-push.yaml
@@ -364,6 +364,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      timeout: 1h30m
       when:
       - input: $(params.skip-checks)
         operator: in


### PR DESCRIPTION
Clamav scan seems to fail due to too restrictive timeout. From passing builds I can see that Clamav pass i.e. in 59 minutes and 59 seconds.

<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass