### PR TITLE
 Disallow installing `transformers >= 4.41`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 accelerate>=0.20.3
 packaging
-transformers>=4.34.1
+transformers>=4.34.1,<4.41
 torch
 aim==3.19.0
 sentencepiece


### PR DESCRIPTION
Duplicate of https://github.com/foundation-model-stack/fms-hf-tuning/pull/202

`transformers >= 4.41` appears to create a performance regression in the fms-hf-training fine tuning jobs.
This PR prevents the regression to happen in the fms-hf-tuning image by disallowing the installation of `transformers >= 4.41`, meaning that `transformers == 4.40` will be installed.

This fix has been performance tested. It reverts the performance to the level prior to the publication of `transformers 4.41`

* with the regression
![image](https://github.com/foundation-model-stack/fms-hf-tuning/assets/7559202/6603efa2-ef24-408c-a5bb-df3dd664324b)

* with the fix
![image](https://github.com/foundation-model-stack/fms-hf-tuning/assets/7559202/a57b010b-fc12-47b1-9eba-7ccf9c5e53bb)


See also: [RHOAIENG-8551](https://issues.redhat.com/browse/RHOAIENG-8551)

Closes #201



