### PR TITLE
WIP: Pin Disallow installing `transformers >= 4.41`

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -164,5 +164,6 @@ WORKDIR /app
 USER ${USER}
 COPY --from=python-installations /home/${USER}/.local /home/${USER}/.local
 ENV PYTHONPATH="/home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages"
+RUN pip install transformers==4.40.2
 
 CMD [ "python", "/app/accelerate_launch.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 accelerate>=0.20.3
 packaging
-transformers>=4.34.1,<4.41
+transformers==4.40.2
 torch
 aim==3.19.0
 sentencepiece


### PR DESCRIPTION
Follow up of https://github.com/red-hat-data-services/fms-hf-tuning/pull/19, which didn't work as expected